### PR TITLE
overseer: helpers to ADD and to DROP

### DIFF
--- a/index.html
+++ b/index.html
@@ -295,6 +295,30 @@
               <code>[data-color-scheme]</code> selector &mdash; toggle the theme in the header to see it.</p>
           </div>
         </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <div class="h-100p border p-24 bg-primary">
+            <h3 class="h5 mb-8">Gap &amp; native grid</h3>
+            <p class="p3 mb-0">Modern spacing and layout &mdash; <code>.gap-16</code>,
+              <code>.gap-x-8</code>, and native CSS grid via <code>.d-grid</code> +
+              <code>.grid-cols-3</code>, alongside the classic flex grid.</p>
+          </div>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <div class="h-100p border p-24 bg-primary">
+            <h3 class="h5 mb-8">Logical &amp; RTL spacing</h3>
+            <p class="p3 mb-0">Writing-direction-aware spacing &mdash; <code>.m-inline-16</code>,
+              <code>.p-block-8</code> &mdash; plus <code>.aspect-16x9</code> ratios and the
+              <code>.inset-0</code> shorthand.</p>
+          </div>
+        </div>
+        <div class="col-12 col-md-6 col-lg-4">
+          <div class="h-100p border p-24 bg-primary">
+            <h3 class="h5 mb-8">Fluid scale &amp; effects</h3>
+            <p class="p3 mb-0">A <code>fluid()</code> <code>clamp()</code> helper for type and spacing
+              that scales with the viewport, plus ready-made <code>.transition</code>,
+              <code>.cursor-pointer</code> and <code>.opacity-50</code> classes.</p>
+          </div>
+        </div>
       </div>
 
       <div class="container">

--- a/site/src/markup/docs/configuration/index.md
+++ b/site/src/markup/docs/configuration/index.md
@@ -38,6 +38,25 @@ $border-radiuses:        0,4,6,8,16,24,32;
 A negative value renders as a double dash in the class name: `-32` → `.mt--32`
 (`margin-top: -32px`).
 
+## Z-layers
+
+Named stacking levels resolved by the `z()` helper (see
+[Functions & Mixins](../functions/)). Separate from the numeric `$z-index`
+scale used by the `.z-*` utility classes.
+
+```scss
+$z-layers: (
+  base:     0,
+  dropdown: 10,
+  sticky:   20,
+  overlay:  30,
+  modal:    40,
+  popover:  50,
+  toast:    60,
+  tooltip:  70
+);
+```
+
 ## Orientations
 
 The per-side suffixes shared by margin, padding, border, position, etc.
@@ -211,11 +230,3 @@ $button: (
 ```
 
 See [Buttons](../buttons/).
-
-## Images
-
-```scss
-$image-dir: '../images/';   // relative to the compiled .css
-```
-
-Base path used by the `bg-image()` / `icon()` helper mixins.

--- a/site/src/markup/docs/effects/index.md
+++ b/site/src/markup/docs/effects/index.md
@@ -17,6 +17,37 @@ Prefix: `filter`. Property: `filter`. Not responsive.
 |---|---|
 | `.filter-invert` | `filter: invert(1)` |
 
+## Opacity
+
+Prefix: `opacity`. Property: `opacity`. Not responsive.
+
+| Class | CSS |
+|---|---|
+| `.opacity-0` | `opacity: 0` |
+| `.opacity-25` | `opacity: 0.25` |
+| `.opacity-50` | `opacity: 0.5` |
+| `.opacity-75` | `opacity: 0.75` |
+| `.opacity-100` | `opacity: 1` |
+
+## Cursor
+
+Prefix: `cursor`. Property: `cursor`. Not responsive.
+
+| Class | CSS |
+|---|---|
+| `.cursor-auto` | `cursor: auto` |
+| `.cursor-default` | `cursor: default` |
+| `.cursor-pointer` | `cursor: pointer` |
+| `.cursor-wait` | `cursor: wait` |
+| `.cursor-text` | `cursor: text` |
+| `.cursor-move` | `cursor: move` |
+| `.cursor-grab` | `cursor: grab` |
+| `.cursor-grabbing` | `cursor: grabbing` |
+| `.cursor-not-allowed` | `cursor: not-allowed` |
+| `.cursor-help` | `cursor: help` |
+| `.cursor-progress` | `cursor: progress` |
+| `.cursor-none` | `cursor: none` |
+
 ## Z-index
 
 Prefix: `z`. Property: `z-index`. Responsive.
@@ -45,6 +76,20 @@ Responsive pattern: `.z-{bp}-{value}`
 .z-md-10   → z-index: 10  (min-width: 768px)
 .z-lg-50   → z-index: 50  (min-width: 1024px)
 ```
+
+## Transition classes
+
+Ready-made utility classes. Not responsive. Each uses the default 250ms duration and `ease-in-out-quint` easing from the transition mixin below.
+
+| Class | CSS |
+|---|---|
+| `.transition` | `transition: all …` |
+| `.transition-colors` | `transition: color, background-color, border-color …` |
+| `.transition-transform` | `transition: transform …` |
+| `.transition-opacity` | `transition: opacity …` |
+| `.transition-none` | `transition: none` |
+
+These complement the SCSS `transition` mixin documented below.
 
 ## Transition mixin (SCSS API)
 

--- a/site/src/markup/docs/flexbox/index.md
+++ b/site/src/markup/docs/flexbox/index.md
@@ -45,6 +45,8 @@ Single-property utility classes generated from `src/core/layout/_flex.scss`. All
 |---|---|
 | `.flex-grow-0` | `flex-grow: 0` |
 | `.flex-grow-1` | `flex-grow: 1` |
+| `.flex-grow-2` | `flex-grow: 2` |
+| `.flex-grow-3` | `flex-grow: 3` |
 
 ---
 
@@ -67,13 +69,9 @@ Single-property utility classes generated from `src/core/layout/_flex.scss`. All
 |---|---|
 | `.align-normal` | `align-items: normal` |
 | `.align-center` | `align-items: center` |
-| `.align-flex-start` | `align-items: flex-start` |
-| `.align-flex-end` | `align-items: flex-end` |
 | `.align-start` | `align-items: start` |
 | `.align-end` | `align-items: end` |
 | `.align-stretch` | `align-items: stretch` |
-
-> Note: `flex-start`/`flex-end` variants are kept for compatibility. Prefer `start`/`end` going forward (see source TODO for v1.1.0).
 
 ---
 
@@ -85,8 +83,6 @@ Single-property utility classes generated from `src/core/layout/_flex.scss`. All
 |---|---|
 | `.justify-normal` | `justify-content: normal` |
 | `.justify-center` | `justify-content: center` |
-| `.justify-flex-start` | `justify-content: flex-start` |
-| `.justify-flex-end` | `justify-content: flex-end` |
 | `.justify-start` | `justify-content: start` |
 | `.justify-end` | `justify-content: end` |
 | `.justify-space-between` | `justify-content: space-between` |

--- a/site/src/markup/docs/functions/index.md
+++ b/site/src/markup/docs/functions/index.md
@@ -44,6 +44,19 @@ padding: helpers.toEm(8px); // → 0.5em
 
 ---
 
+## Fluid sizing
+
+### `fluid($min, $max, $min-vw: 420px, $max-vw: 1680px)`
+
+Returns a `clamp()` expression that scales a `px` value linearly with the viewport between `$min-vw` and `$max-vw`, clamped at both ends. px in, rem out.
+
+```scss
+font-size: helpers.fluid(16px, 24px);
+// → clamp(1rem, 0.8333333333rem + 0.6349206349vw, 1.5rem)
+```
+
+---
+
 ## Color
 
 ### `color($name)`
@@ -63,6 +76,16 @@ Pulls the raw SCSS value from `config.$colors` (or a named color mode map) at co
 $brand: helpers.get-color(primary);         // raw value from $colors
 $dark:  helpers.get-color(primary, 'dark'); // raw value from $color-modes.dark
 ```
+
+### `z($name)`
+
+Returns a named stacking level from the `config.$z-layers` map. Warns and returns `auto` for an unknown name.
+
+```scss
+z-index: helpers.z(modal); // → 40
+```
+
+The map ships as: `base` 0, `dropdown` 10, `sticky` 20, `overlay` 30, `modal` 40, `popover` 50, `toast` 60, `tooltip` 70.
 
 ---
 
@@ -128,7 +151,7 @@ Sets `::selection` background to the named color (resolved via `color()`).
 
 ### `placeholder($color)` mixin
 
-Sets placeholder text color across all vendor prefixes (`::placeholder`, `:-ms-input-placeholder`, etc.).
+Sets placeholder text color via the standard `::placeholder` selector.
 
 ```scss
 input {
@@ -138,39 +161,22 @@ input {
 
 ---
 
-## Background & icon image helpers
+## String & map helpers
 
-### `bg-image($filename, $ext: png)` mixin
+### `str-split($string, $separator)`
 
-Sets `background-image` to `config.$image_dir + filename + .ext`.
+Splits a string into a list on each occurrence of `$separator`.
 
 ```scss
-.hero { @include helpers.bg-image('hero-bg'); }
-// → background-image: url('/images/hero-bg.png');
+helpers.str-split('a.b.c', '.'); // → 'a' 'b' 'c'  (list of length 3)
 ```
 
-### `bg-image-retina($filename, $ext: png)` mixin
+### `map-deep-get($map, $keys...)`
 
-Same as `bg-image` but also adds a high-DPI media query that swaps in a `@2x` variant.
-
-```scss
-.logo { @include helpers.bg-image-retina('logo'); }
-```
-
-### `icon($filename, $w, $h, $ext: png)` mixin
-
-Renders an inline icon via `background-image`. Sets `width`, `height`, `background-size`, `display: inline-block`, `vertical-align: middle`, and centers the image.
+Fetches a nested map value by a path of keys.
 
 ```scss
-.icon-close { @include helpers.icon('close', 16px, 16px); }
-```
-
-### `icon-retina($filename, $w, $h, $ext: png)` mixin
-
-Same as `icon` but swaps in a `@2x` file on high-DPI displays.
-
-```scss
-.icon-close { @include helpers.icon-retina('close', 16px, 16px); }
+helpers.map-deep-get((a: (b: 42)), a, b); // → 42
 ```
 
 ---
@@ -226,17 +232,16 @@ This emits classes like `.p-0`, `.p-8`, `.pt-16`, `.pb-32`, and breakpoint varia
 
 ## Browser fixes (`_fixes.scss`)
 
-Three mixins for targeted rendering quirks. Include only where needed.
+Two mixins for targeted rendering quirks. Include only where needed.
 
 | Mixin | Effect |
 |---|---|
-| `rounded-container-fix()` | Fixes `overflow: hidden` clipping with `border-radius` in WebKit via `-webkit-mask-image` |
 | `animate-scale-fix()` | Prevents jank on `transform: scale()` animations by forcing GPU compositing layer (`backface-visibility: hidden`, `transform-style: preserve-3d`) |
 | `clearfix()` | Classic `::after` float-clearing pattern |
 
 ```scss
 .card {
-  @include gen.rounded-container-fix();
+  @include gen.animate-scale-fix();
 }
 ```
 

--- a/site/src/markup/docs/getting-started/index.md
+++ b/site/src/markup/docs/getting-started/index.md
@@ -80,7 +80,7 @@ defaults.
 
 ```html
 <div class="container">
-  <div class="d-flex justify-content-between items-center p-24">
+  <div class="d-flex justify-space-between align-center p-24">
     <h1 class="h3 mb-0 text-primary">🜍 Hello</h1>
     <button class="btn">Click me</button>
   </div>
@@ -88,7 +88,7 @@ defaults.
 ```
 
 - `.container` — centred, max-width wrapper.
-- `.d-flex`, `.justify-content-between`, `.items-center` — flexbox layout.
+- `.d-flex`, `.justify-space-between`, `.align-center` — flexbox layout.
 - `.p-24` — `padding: 24px`.
 - `.h3` — heading-3 typography without an `<h3>` tag.
 - `.mb-0` — `margin-bottom: 0`.

--- a/site/src/markup/docs/grid/index.md
+++ b/site/src/markup/docs/grid/index.md
@@ -144,3 +144,23 @@ Use `.col-N-max` when you want an element to grow freely on small screens but ne
 ```html
 <img class="col-6-max" src="photo.jpg" alt="">
 ```
+
+## Native CSS grid
+
+Separate from the 12-column flex system above, these utilities drive a real `display: grid` container.
+
+| Class | CSS |
+|---|---|
+| `.d-grid` | `display: grid` |
+| `.d-inline-grid` | `display: inline-grid` |
+| `.grid-cols-{n}` | `grid-template-columns: repeat({n}, minmax(0, 1fr))` |
+
+`.grid-cols-{n}` is generated for `n` = 1–12 and has responsive variants (`.grid-cols-md-3`). Pair with the `.gap-*` utilities for gutters.
+
+```html
+<div class="d-grid grid-cols-1 grid-cols-md-3 gap-16">
+  <div>Cell A</div>
+  <div>Cell B</div>
+  <div>Cell C</div>
+</div>
+```

--- a/site/src/markup/docs/position/index.md
+++ b/site/src/markup/docs/position/index.md
@@ -72,6 +72,20 @@ Same four prefixes. Unit: `%`. A `p` suffix marks percentage classes.
 .l--100p           → left: -100%
 ```
 
+## Inset
+
+Prefix: `inset`. Property: `inset`. Sets all four offsets at once — a shorthand that complements the single-side `t`/`r`/`b`/`l` utilities.
+
+Uses the standard `$sizes` scale, plus negatives, percentages (`p` suffix), and `auto`. Responsive variants exist.
+
+```
+.inset-16          → inset: 16px
+.inset--16         → inset: -16px
+.inset-50p         → inset: 50%
+.inset-auto        → inset: auto
+.inset-md-16       → inset: 16px  (min-width: 768px)
+```
+
 ## Z-index
 
 Prefix: `z`. Property: `z-index`.
@@ -125,20 +139,14 @@ Static single-purpose classes, no responsive variants.
 
 ```
 .absolute-cover    → position: absolute; top: 0; left: 0; width: 100%; height: 100%
-.cover             → top: 0; left: 0; width: 100%; height: 100%  (no position set)
 ```
 
 **Absolute centering**
 
 ```
 .absolute-center   → position: absolute; top: 50%; left: 50%; transform: translate3d(-50%, -50%, 0)
-.self-center       → transform: translate3d(-50%, -50%, 0)
-
 .absolute-center-vertical   → position: absolute; top: 50%; transform: translateY(-50%)
-.self-center-vertical       → transform: translateY(-50%)
-
 .absolute-center-horizontal → position: absolute; left: 50%; transform: translateX(-50%)
-.self-center-horizontal     → transform: translateX(-50%)
 ```
 
 **Background sizing**

--- a/site/src/markup/docs/sizing/index.md
+++ b/site/src/markup/docs/sizing/index.md
@@ -125,6 +125,19 @@ Property: `max-height`. Same two values.
 .h-max-100p { max-height: 100%; }
 ```
 
+## Aspect ratio — `.aspect-*`
+
+Property: `aspect-ratio`. Not responsive.
+
+```css
+.aspect-1x1  { aspect-ratio: 1 / 1; }
+.aspect-4x3  { aspect-ratio: 4 / 3; }
+.aspect-3x2  { aspect-ratio: 3 / 2; }
+.aspect-16x9 { aspect-ratio: 16 / 9; }
+.aspect-21x9 { aspect-ratio: 21 / 9; }
+.aspect-9x16 { aspect-ratio: 9 / 16; }
+```
+
 ## Responsive variants
 
 Every `w-*`, `h-*`, `w-max-*`, and `h-max-*` class is also generated inside a

--- a/site/src/markup/docs/spacing/index.md
+++ b/site/src/markup/docs/spacing/index.md
@@ -70,6 +70,40 @@ Prefix: `p`. Property: `padding`. Same `$sizes` scale. No negatives, no `auto`.
 | `.px-{size}` | `padding-left` + `padding-right` |
 | `.py-{size}` | `padding-top` + `padding-bottom` |
 
+## Gap
+
+Prefix: `gap`. Generated from the `$sizes` scale. Responsive.
+
+| Class pattern | CSS property |
+|---|---|
+| `.gap-{size}` | `gap` |
+| `.gap-x-{size}` | `column-gap` |
+| `.gap-y-{size}` | `row-gap` |
+
+```
+.gap-16            → gap: 16px
+.gap-x-8           → column-gap: 8px
+.gap-y-24          → row-gap: 24px
+.gap-md-16         → gap: 16px  (min-width: 768px)
+```
+
+## Logical spacing (RTL-aware)
+
+The `x`/`y` axis shorthands above map to physical sides (left/right, top/bottom). The logical variants below map to **writing-direction-aware** sides, so they flip automatically under RTL. Same scales as margin/padding. Responsive.
+
+| Class pattern | CSS property |
+|---|---|
+| `.m-inline-{size}` | `margin-inline` |
+| `.m-block-{size}` | `margin-block` |
+| `.p-inline-{size}` | `padding-inline` |
+| `.p-block-{size}` | `padding-block` |
+
+```
+.m-inline-16       → margin-inline: 16px
+.p-block-24        → padding-block: 24px
+.m-inline-md-16    → margin-inline: 16px  (min-width: 768px)
+```
+
 ## Quick reference
 
 ```

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -4,6 +4,8 @@
 $sizes: 0,1,2,3,4,6,8,12,14,16,24,32,40,48,56,64,80,96,128,256 !default;
 $negative-sizes: -1,-2,-3,-4,-8,-12,-14,-16,-24,-32,-40,-48,-56,-64 !default;
 $percent-sizes: 5,10,15,20,25,50,75,100 !default;
+// Feeds position offsets (top/right/bottom/left/inset) only — never width/height,
+// where a negative percentage would be meaningless. See layout/_position.scss.
 $negative-percent-sizes: -5,-10,-15,-20,-25,-50,-75,-100 !default;
 $z-index: -1,0,1,2,3,4,5,10,15,20,25,50,100 !default;
 

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -7,6 +7,21 @@ $percent-sizes: 5,10,15,20,25,50,75,100 !default;
 $negative-percent-sizes: -5,-10,-15,-20,-25,-50,-75,-100 !default;
 $z-index: -1,0,1,2,3,4,5,10,15,20,25,50,100 !default;
 
+/*
+ * Z-LAYERS - named stacking levels for the `z()` helper, so stacking is a
+ * token (`z(modal)`) instead of a raw magic number.
+ */
+$z-layers: (
+  'base': 0,
+  'dropdown': 10,
+  'sticky': 20,
+  'overlay': 30,
+  'modal': 40,
+  'popover': 50,
+  'toast': 60,
+  'tooltip': 70
+) !default;
+
 $border-sizes: 2,3,4,6,8 !default;
 $border-radiuses: 0,4,6,8,16,24,32 !default;
 

--- a/src/core/_config.scss
+++ b/src/core/_config.scss
@@ -155,6 +155,3 @@ $button: (
   border-width: 2px,
   border-radius: 4px
 ) !default;
-
-//Image directory default - change it to wherever you store images relative to the compiled .css
-$image-dir: '../images/' !default;

--- a/src/core/layout/_aspect.scss
+++ b/src/core/layout/_aspect.scss
@@ -1,0 +1,16 @@
+@use '../utils/generators';
+
+// Aspect-ratio utilities. `.aspect-16x9`, `.aspect-1x1`, ...
+@include generators.utility-class-generator((
+  prefix: 'aspect',
+  property: 'aspect-ratio',
+  values: (
+    '1x1': '1 / 1',
+    '4x3': '4 / 3',
+    '3x2': '3 / 2',
+    '16x9': '16 / 9',
+    '21x9': '21 / 9',
+    '9x16': '9 / 16'
+  ),
+  responsive: false
+));

--- a/src/core/layout/_display.scss
+++ b/src/core/layout/_display.scss
@@ -1,3 +1,3 @@
 @use '../utils/generators';
 
-@include generators.utility-class-generator('d', 'display', ('block', 'inline', 'flex', 'inline-block', 'none', 'table', 'table-cell', 'inline-flex'));
+@include generators.utility-class-generator('d', 'display', ('block', 'inline', 'flex', 'inline-block', 'none', 'table', 'table-cell', 'inline-flex', 'grid', 'inline-grid'));

--- a/src/core/layout/_flex.scss
+++ b/src/core/layout/_flex.scss
@@ -2,10 +2,10 @@
 
 @include generators.utility-class-generator('flex', 'flex-direction', ('row', 'row-reverse', 'column', 'column-reverse'));
 @include generators.utility-class-generator('flex', 'flex-wrap', ('wrap', 'nowrap'));
-@include generators.utility-class-generator('flex-grow', 'flex-grow', (0, 1));
+@include generators.utility-class-generator('flex-grow', 'flex-grow', (0, 1, 2, 3));
+// ponytail: flex-shrink 0/1 covers the common cases; grow the scale if a real need shows up
 @include generators.utility-class-generator('flex-shrink', 'flex-shrink', (0, 1));
-// TODO: Prefer 'end' and 'start' over 'flex-end' and 'flex-start' in v1.1.0
-@include generators.utility-class-generator('align', 'align-items', ('normal', 'center', 'flex-start', 'flex-end', 'end', 'start', 'stretch'));
-@include generators.utility-class-generator('justify', 'justify-content', ('normal', 'center', 'flex-start', 'flex-end', 'end', 'start', 'space-between', 'space-around'));
+@include generators.utility-class-generator('align', 'align-items', ('normal', 'center', 'start', 'end', 'stretch'));
+@include generators.utility-class-generator('justify', 'justify-content', ('normal', 'center', 'start', 'end', 'space-between', 'space-around'));
 @include generators.utility-class-generator('align-self', 'align-self', ('normal', 'center', 'start', 'end', 'stretch'));
 @include generators.utility-class-generator('justify-self', 'justify-self', ('normal', 'center', 'start', 'end', 'stretch'));

--- a/src/core/layout/_gap.scss
+++ b/src/core/layout/_gap.scss
@@ -1,0 +1,7 @@
+@use '../config';
+@use '../utils/generators';
+
+// Flex/grid gap. `.gap-16`, plus axis variants `.gap-x-*` (column) / `.gap-y-*` (row).
+@include generators.utility-class-generator('gap', 'gap', config.$sizes, 'px');
+@include generators.utility-class-generator('gap-x', 'column-gap', config.$sizes, 'px');
+@include generators.utility-class-generator('gap-y', 'row-gap', config.$sizes, 'px');

--- a/src/core/layout/_grid.scss
+++ b/src/core/layout/_grid.scss
@@ -46,6 +46,9 @@
 @include generators.grid-offset-generator(config.$columns);
 @include generators.grid-column-max-generator(config.$columns);
 
+// Native CSS grid (`display: grid` via `.d-grid`) column templates.
+@include generators.grid-template-generator(config.$columns);
+
 .grid-reverse {
   flex-direction: row-reverse;
 }

--- a/src/core/layout/_margin.scss
+++ b/src/core/layout/_margin.scss
@@ -15,3 +15,7 @@ $margin-sizes: list.append(config.$sizes, 'auto');
   unit: 'px',
   orientations: config.$orientations
 ));
+
+// Logical-property margins (RTL-aware). `.m-inline-16` => margin-inline: 16px
+@include generators.utility-class-generator('m-inline', 'margin-inline', $margin-sizes, 'px');
+@include generators.utility-class-generator('m-block', 'margin-block', $margin-sizes, 'px');

--- a/src/core/layout/_misc.scss
+++ b/src/core/layout/_misc.scss
@@ -17,48 +17,31 @@
 }
 
 
-// TODO: v1.1.0 check if having absolute- classes is necessary, maybe .self-center .position-absolute? Is it worth it?
-.absolute-cover,
-.cover {
+.absolute-cover {
   height: 100%;
   left: 0;
+  position: absolute;
   top: 0;
   width: 100%;
-}
-
-.absolute-cover {
-  position: absolute;
-}
-
-.absolute-center,
-.self-center {
-  transform: translate3d(-50%, -50%, 0);
-}
-
-.absolute-center-vertical,
-.self-center-vertical {
-  transform: translateY(-50%);
-}
-
-.absolute-center-horizontal,
-.self-center-horizontal {
-  transform: translateX(-50%);
 }
 
 .absolute-center {
   left: 50%;
   position: absolute;
   top: 50%;
+  transform: translate3d(-50%, -50%, 0);
 }
 
 .absolute-center-vertical {
   position: absolute;
   top: 50%;
+  transform: translateY(-50%);
 }
 
 .absolute-center-horizontal {
   left: 50%;
   position: absolute;
+  transform: translateX(-50%);
 }
 
 .bg-cover {

--- a/src/core/layout/_padding.scss
+++ b/src/core/layout/_padding.scss
@@ -8,3 +8,7 @@
   unit: 'px',
   orientations: config.$orientations
 ));
+
+// Logical-property padding (RTL-aware). `.p-inline-16` => padding-inline: 16px
+@include generators.utility-class-generator('p-inline', 'padding-inline', config.$sizes, 'px');
+@include generators.utility-class-generator('p-block', 'padding-block', config.$sizes, 'px');

--- a/src/core/layout/_position.scss
+++ b/src/core/layout/_position.scss
@@ -21,5 +21,11 @@
 @include generators.utility-class-generator('b', 'bottom', config.$negative-percent-sizes, '%', 'p');
 @include generators.utility-class-generator('l', 'left', config.$negative-percent-sizes, '%', 'p');
 
+// `inset` shorthand — sets top/right/bottom/left at once, complements t/r/b/l.
+@include generators.utility-class-generator('inset', 'inset', config.$sizes, 'px');
+@include generators.utility-class-generator('inset', 'inset', config.$negative-sizes, 'px');
+@include generators.utility-class-generator('inset', 'inset', config.$percent-sizes, '%', 'p');
+@include generators.utility-class-generator('inset', 'inset', ('auto'));
+
 @include generators.utility-class-generator('position', 'position', ('static', 'absolute', 'fixed', 'relative', 'sticky'));
 @include generators.utility-class-generator('z', 'z-index', (config.$z-index));

--- a/src/core/layout/index.scss
+++ b/src/core/layout/index.scss
@@ -10,6 +10,7 @@
 @use 'gap';
 @use 'position';
 @use 'dimension';
+@use 'aspect';
 @use 'container';
 @use 'flex';
 @use 'float';

--- a/src/core/layout/index.scss
+++ b/src/core/layout/index.scss
@@ -7,6 +7,7 @@
 @use 'overflow';
 @use 'margin';
 @use 'padding';
+@use 'gap';
 @use 'position';
 @use 'dimension';
 @use 'container';

--- a/src/core/style/_border.scss
+++ b/src/core/style/_border.scss
@@ -1,5 +1,4 @@
 @use '../config';
-@use '../utils/fixes';
 @use '../utils/generators';
 
 // Utility classes intentionally @extend the concrete `.border` class and reset
@@ -65,10 +64,6 @@
 
 [class*='rounded-'] {
   overflow: hidden;
-}
-
-.rounded-fix {
-  @include fixes.rounded-container-fix; //FYI: rounded fix is for fixing images only, if enabled on rounded block with shadow it will disable the shadow.
 }
 
 @include generators.utility-class-generator('rounded', 'border-radius', config.$border-radiuses, 'px', '', false, false);

--- a/src/core/style/_effects.scss
+++ b/src/core/style/_effects.scss
@@ -1,0 +1,41 @@
+@use '../utils/generators';
+
+// Opacity. `.opacity-50` => opacity: 0.5
+@include generators.utility-class-generator((
+  prefix: 'opacity',
+  property: 'opacity',
+  values: (0: 0, 25: 0.25, 50: 0.5, 75: 0.75, 100: 1),
+  responsive: false
+));
+
+// Cursor.
+@include generators.utility-class-generator(
+  'cursor',
+  'cursor',
+  ('auto', 'default', 'pointer', 'wait', 'text', 'move', 'grab', 'grabbing', 'not-allowed', 'help', 'progress', 'none'),
+  '',
+  '',
+  false,
+  false
+);
+
+// Ready-made transition classes backed by the `transition` mixin.
+.transition {
+  @include generators.transition(all);
+}
+
+.transition-colors {
+  @include generators.transition((color, background-color, border-color));
+}
+
+.transition-transform {
+  @include generators.transition(transform);
+}
+
+.transition-opacity {
+  @include generators.transition(opacity);
+}
+
+.transition-none {
+  transition: none;
+}

--- a/src/core/style/index.scss
+++ b/src/core/style/index.scss
@@ -4,3 +4,4 @@
 @forward 'list';
 @forward 'typography';
 @forward 'filters';
+@forward 'effects';

--- a/src/core/utils/_fixes.scss
+++ b/src/core/utils/_fixes.scss
@@ -1,10 +1,5 @@
 /* stylelint-disable */
 
-// fixes overflow hidden container with border-radius
-@mixin rounded-container-fix() {
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
-}
-
 // fixes jump on animateing transform scale
 @mixin animate-scale-fix() {
   -webkit-transform-style: preserve-3d;

--- a/src/core/utils/_generators.scss
+++ b/src/core/utils/_generators.scss
@@ -383,6 +383,30 @@ $breakpoints: config.$breakpoints;
   }
 }
 
+// Native CSS-grid column templates: `.grid-cols-3` => 3 equal minmax(0,1fr)
+// tracks. Pair with `.d-grid` and `.gap-*`. Responsive by default.
+@mixin grid-template-generator($columns, $responsive: true) {
+  @for $i from 1 through $columns {
+    .grid-cols-#{$i} {
+      grid-template-columns: repeat(#{$i}, minmax(0, 1fr));
+    }
+  }
+
+  @if $responsive {
+    @each $b-name, $b-value in $breakpoints {
+      @if $b-name != '' and $b-name != 'min' and $b-name != 'minimal' {
+        @media #{generate-breakpoint($b-name)} {
+          @for $i from 1 through $columns {
+            .grid-cols-#{$b-name}-#{$i} {
+              grid-template-columns: repeat(#{$i}, minmax(0, 1fr));
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
 @function get-min-breakpoint-value() {
   $value: 0;
 

--- a/src/core/utils/_helpers.scss
+++ b/src/core/utils/_helpers.scss
@@ -83,30 +83,31 @@
   @return $string;
 }
 
-// stylelint-disable max-nesting-depth -- nested @for/@if is inherent to the sort
-@function bubble-sort($list) {
-  $length: list.length($list);
-  $temp: null;
+// ponytail: insertion sort — fine for N≈5 breakpoints; swap for list.sort()
+// once it lands in Dart Sass if this ever sorts bigger lists.
+@function sort-numbers($list) {
+  $sorted: ();
 
-  @for $i from 1 through $length {
-    @for $j from 1 through $length - $i {
-      @if $j == 0 {
-        $j: 1;
-      }
-      $a: list.nth($list, $j);
-      $b: list.nth($list, $j + 1);
+  @each $item in $list {
+    $placed: false;
+    $new: ();
 
-      @if $a > $b {
-        $temp: $a;
-        $list: list.set-nth($list, $j, $b);
-        $list: list.set-nth($list, $j + 1, $temp);
+    @each $s in $sorted {
+      @if not $placed and $item < $s {
+        $new: list.append($new, $item);
+        $placed: true;
       }
+      $new: list.append($new, $s);
     }
+
+    @if not $placed {
+      $new: list.append($new, $item);
+    }
+    $sorted: $new;
   }
 
-  @return $list;
+  @return $sorted;
 }
-// stylelint-enable max-nesting-depth
 
 
 @function reverse-map($map, $rm-unit: false) {
@@ -130,7 +131,7 @@
   $values-list: map.keys($reverse-map);
   $sorted-values: $values-list;
   @if list.length($values-list) > 1 {
-    $sorted-values: bubble-sort($values-list);
+    $sorted-values: sort-numbers($values-list);
   }
   $breakpoints: ();
   $min: false;

--- a/src/core/utils/_helpers.scss
+++ b/src/core/utils/_helpers.scss
@@ -223,6 +223,16 @@
   @return $breakpoints;
 }
 
+// Named stacking level from config.$z-layers. `z(modal)` → 40
+@function z($name) {
+  @if map.has-key(config.$z-layers, $name) {
+    @return map.get(config.$z-layers, $name);
+  }
+
+  @warn '🜍 Undefined z-layer: `#{$name}`! Please check your `_config.scss`.';
+  @return auto;
+}
+
 @mixin selection($color: primary) {
   ::selection { background: color($color); }
 }

--- a/src/core/utils/_helpers.scss
+++ b/src/core/utils/_helpers.scss
@@ -42,6 +42,29 @@
   @return $value;
 }
 
+/*
+ * Fluid value between two breakpoints via `clamp()`. Scales linearly with the
+ * viewport from $min-vw to $max-vw, then clamps at both ends. px in, rem out.
+ *
+ * @param $min      smallest value (e.g. 16px)
+ * @param $max      largest value (e.g. 24px)
+ * @param $min-vw   viewport where scaling starts (default: smallest breakpoint)
+ * @param $max-vw   viewport where scaling ends (default: largest breakpoint)
+ * @return e.g. `clamp(1rem, 0.833rem + 0.635vw, 1.5rem)`
+ */
+@function fluid($min, $max, $min-vw: 420px, $max-vw: 1680px) {
+  $min-u: rm-unit($min);
+  $max-u: rm-unit($max);
+  $min-vw-u: rm-unit($min-vw);
+  $max-vw-u: rm-unit($max-vw);
+
+  $slope: math.div($max-u - $min-u, $max-vw-u - $min-vw-u);
+  $intercept: $min-u - $slope * $min-vw-u;
+
+  // clamp()/min()/max() allow bare calc math, no calc() wrapper needed
+  @return clamp(#{toRem($min)}, #{toRem($intercept * 1px)} + #{$slope * 100}vw, #{toRem($max)});
+}
+
 @function color($color) {
   @if map.has-key(config.$colors, $color) {
     @return var(--color-#{$color});
@@ -81,6 +104,29 @@
   }
 
   @return $string;
+}
+
+// Split a string on a separator into a list. `str-split('a.b.c', '.')` → 'a' 'b' 'c'
+@function str-split($string, $separator) {
+  $result: ();
+  $index: string.index($string, $separator);
+
+  @while $index != null {
+    $result: list.append($result, string.slice($string, 1, $index - 1));
+    $string: string.slice($string, $index + string.length($separator));
+    $index: string.index($string, $separator);
+  }
+
+  @return list.append($result, $string);
+}
+
+// Fetch a nested map value by a path of keys. `map-deep-get($m, 'a', 'b')`
+@function map-deep-get($map, $keys...) {
+  @each $key in $keys {
+    $map: map.get($map, $key);
+  }
+
+  @return $map;
 }
 
 // ponytail: insertion sort — fine for N≈5 breakpoints; swap for list.sort()

--- a/src/core/utils/_helpers.scss
+++ b/src/core/utils/_helpers.scss
@@ -181,49 +181,6 @@
   ::selection { background: color($color); }
 }
 
-/* stylelint-disable */
-
-//TODO: CHECK 👇
-
 @mixin placeholder($color) {
-  &::-webkit-input-placeholder,
-  &::-moz-placeholder,
-  &:-ms-input-placeholder,
-  &:-moz-placeholder,
-  &::placeholder {
-    color: color($color);
-  }
-}
-
-@mixin bg-image($filename, $ext: png) {
-  background-image: url('#{config.$image_dir}#{$filename}.#{$ext}');
-}
-
-@mixin bg-image-retina($filename, $ext: png) {
-  @include bg-image($filename, $ext);
-
-  @media only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen and (min--moz-device-pixel-ratio: 1.3), only screen and (-o-min-device-pixel-ratio: 1.3 / 1), only screen and (min-resolution: 125dpi), only screen and (min-resolution: 1.3dppx) {
-    background-image: url('#{config.$image_dir}#{$filename}@2x.#{$ext}');
-  }
-}
-
-@mixin icon($filename, $w, $h, $ext: png) {
-  background-image: url('#{config.$image_dir}#{$filename}.#{$ext}');
-  background-size: $w $h;
-  background-position: center center;
-  background-repeat: no-repeat;
-  display: inline-block;
-  width: $w;
-  height: $h;
-  line-height: $h;
-  vertical-align: middle;
-  margin-top: -3px;
-}
-
-@mixin icon-retina($filename, $w, $h, $ext: png) {
-  @include icon($filename, $w, $h, $ext);
-
-  @media only screen and (-webkit-min-device-pixel-ratio: 1.3), only screen and (min--moz-device-pixel-ratio: 1.3), only screen and (-o-min-device-pixel-ratio: 1.3 / 1), only screen and (min-resolution: 125dpi), only screen and (min-resolution: 1.3dppx) {
-    background-image: url('#{config.$image_dir}#{$filename}@2x.#{$ext}');
-  }
+  &::placeholder { color: color($color); }
 }


### PR DESCRIPTION
Closes #63

# Issue #63 — helpers to ADD and to DROP

Reviewed both layers (SCSS helpers/mixins + utility class families), then applied
add/drop/modify. 16 commits, one per subtask. Build (`sass`), `tsc --noEmit`, and
`stylelint` all pass. `dist/` intentionally not regenerated (see Notes).

## A. SCSS helpers & mixins

**Dropped / reworked**
- **`bubble-sort` → `sort-numbers` (insertion sort).** Rewrote as a clean insertion
  sort using only `list.append`; removed the dead `@if $j == 0` branch. Only caller
  (`breakpoints()`) updated. Verified breakpoint output byte-identical to before.
  Carries a `// ponytail:` note (fine for N≈5; swap for `list.sort()` if it ever
  lands in Dart Sass).
- **`placeholder` mixin** reduced to the standard `&::placeholder { color }`; the four
  dead vendor prefixes and the `//TODO: CHECK` are gone.
- **`bg-image` / `bg-image-retina` / `icon` / `icon-retina`** removed (sprite-era,
  unused). The now-orphaned `$image-dir` config var removed too.
- **`rounded-container-fix` (`_fixes.scss`)** removed — and with it the `.rounded-fix`
  utility class in `_border.scss` (its only consumer) and the `fixes` import there.

**Kept** — all load-bearing helpers untouched.

**Added**
- **`fluid($min, $max, $min-vw: 420px, $max-vw: 1680px)`** — `clamp()` helper. Linear
  viewport interpolation, clamped both ends; px in, rem out. Uses bare calc math inside
  `clamp()` (no `calc()` wrapper needed). Verified: `fluid(16px, 24px)` →
  `clamp(1rem, 0.8333333333rem + 0.6349206349vw, 1.5rem)`.
- **`str-split($string, $separator)`** → list; **`map-deep-get($map, $keys...)`** →
  nested lookup. Both output-verified.
- **`z($name)`** keyed off a new **`$z-layers`** config map
  (base/dropdown/sticky/overlay/modal/popover/toast/tooltip). Warns + returns `auto`
  on unknown names. The numeric `$z-index` scale (for `.z-*` classes) is unchanged.

## B. Utility class families

**Added**
- **Gap** (`layout/_gap.scss`): `.gap-*` (gap), `.gap-x-*` (column-gap), `.gap-y-*`
  (row-gap), responsive.
- **Native CSS grid**: `.d-grid` / `.d-inline-grid` (added to display), and
  `.grid-cols-{1..12}` → `grid-template-columns: repeat(n, minmax(0,1fr))`, responsive,
  via a new `grid-template-generator` mixin. Separate from the flex `.grid`.
- **Logical-property spacing** (RTL-aware): `.m-inline-*`, `.m-block-*`, `.p-inline-*`,
  `.p-block-*`, responsive. Physical `x`/`y` orientations documented as physical;
  logical variants flip under RTL.
- **Aspect-ratio** (`layout/_aspect.scss`): `.aspect-1x1/4x3/3x2/16x9/21x9/9x16`.
- **Inset** shorthand (position): `.inset-*` for sizes, negatives, percentages (`p`),
  and `auto`, responsive.
- **Effects** (`style/_effects.scss`): `.opacity-0/25/50/75/100`, `.cursor-*`, and
  ready-made `.transition` / `.transition-colors` / `.transition-transform` /
  `.transition-opacity` / `.transition-none` backed by the existing mixin.

**Dropped / reconsidered**
- **`.self-center*` aliases dropped**; the self-sufficient `.absolute-center*` family
  (which also sets position + offsets) is kept. Also collapsed the duplicated shared
  transform rules into each concrete class.
- **`.cover` dropped**; kept the prefixed `.absolute-cover`.
- **`$negative-percent-sizes`**: confirmed it feeds *position offsets only*
  (top/right/bottom/left/inset) — never width/height (the dimension generator uses only
  the positive `$percent-sizes`). Negative-% offsets are valid, so kept, with a config
  comment stating the scope. No dimension leak existed.
- **`flex-grow` expanded to 0–3**; `flex-shrink` kept at 0/1 with a `// ponytail:` note
  explaining the deliberate limit.

**Consistency fixes**
- **align/justify settled on `start`/`end`** — dropped `flex-start`/`flex-end` from
  `align-items` and `justify-content` (and removed the stale v1.1.0 TODO). `start`/`end`
  are valid box-alignment values in flex containers on all modern targets.
- **`.justify-space-between`** chosen as canonical. Docs that referenced the
  nonexistent `.justify-content-between` / `.items-center` (getting-started) fixed to the
  real `.justify-space-between` / `.align-center`.

## Docs & demo
- Updated 9 doc pages (functions, flexbox, getting-started, effects, position, spacing,
  grid, sizing, configuration) to match every add/drop above — new sections for fluid,
  str-split/map-deep-get, z/$z-layers, gap, logical spacing, native grid, aspect-ratio,
  inset, opacity/cursor/transition; removed bg-image/icon/rounded-container-fix/$image-dir
  and the flex-start/flex-end + `.cover`/`.self-center` rows.
- `index.html` demo: added 3 Capabilities cards (Gap & native grid; Logical & RTL
  spacing; Fluid scale & effects) so the landing page reflects the new families, keeping
  the grid a clean 3×3. All referenced classes verified to exist in the compiled output.

## Notes / follow-ups
- **Breaking changes** (worth a minor/major bump from 2.0.1): removed classes
  `.rounded-fix`, `.cover`, `.self-center*`, `.align-flex-start/-end`,
  `.justify-flex-start/-end`; removed mixins `bg-image*`/`icon*`/`rounded-container-fix`;
  `placeholder` slimmed; config var `$image-dir` removed.
- **`str-split`/`map-deep-get` not yet wired into the generators.** The issue suggested
  they could tidy the hand-rolled string slicing / nested `map.get` there. I added the
  helpers but left the generators as-is — that refactor is behavior-neutral churn on
  load-bearing code and is better as its own PR. (Marked here rather than done.)
- **`dist/` not regenerated.** Prior src-changing PRs (#61, #62) didn't touch `dist`;
  it looks built at release/publish time. Left for the release step to avoid a large
  minified diff.
- **`fluid()` defaults** (`420px`/`1680px`) are literals matching the shipped smallest/
  largest breakpoints, not derived from `$breakpoints`. Explicit args override; deriving
  from config would add coupling for little gain.
- Verified via in-process `sass.compile` (the `poops`/CLI paths are sandbox-blocked):
  build OK, `tsc --noEmit` OK, `stylelint src/**/*.scss` CLEAN.

`$8.98 · 9 turns · 1,238,064 in (1,222,627 cached) · 5,504 out`